### PR TITLE
Implement Output Resolution Selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,14 @@
       <option value="oldtv">Old TV</option>
     </select>
   </label>
+  <label>Resolution:
+    <select id="resolution">
+      <option value="dynamic">Window</option>
+      <option value="480p">480p</option>
+      <option value="720p">720p</option>
+      <option value="1080p">1080p</option>
+    </select>
+  </label>
   <button id="start">Convert</button>
   <button id="record">Record</button>
   <button id="stop">Stop</button>
@@ -68,12 +76,13 @@
 <div class="display">
   <video id="video" controls></video>
   <pre id="ascii"></pre>
+  <canvas id="ascii-canvas" style="display:none;"></canvas>
 </div>
 <canvas id="canvas" style="display:none;"></canvas>
 <p id="status"></p>
 
 <!-- ffmpeg.wasm CDN -->
-<script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.js"></script>
+<script src="https://unpkg.com/@ffmpeg/ffmpeg@0.11.0/dist/ffmpeg.min.js"></script>
 
 <script>
 const chars="@#8&$%WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/|()1{}[]?-_+~<>i!lI;:,\"^`'. ";
@@ -82,6 +91,9 @@ const vid=document.getElementById('video');
 const can=document.getElementById('canvas');
 const ctx=can.getContext('2d');
 const asciiOut=document.getElementById('ascii');
+const asciiCanvas=document.getElementById('ascii-canvas');
+const asciiCtx=asciiCanvas.getContext('2d');
+const resolution=document.getElementById('resolution');
 const start=document.getElementById('start');
 const stop=document.getElementById('stop');
 const recBtn=document.getElementById('record');
@@ -104,21 +116,60 @@ stop.onclick=()=>{
 
 function renderLoop(){
   if(!running||vid.paused||vid.ended)return;
-  const width=parseInt(width.value);
-  const font=parseInt(fontsize.value);
-  const fps=parseInt(fps.value);
-  asciiOut.style.fontSize=font+"px";
-  asciiOut.style.background=bg.value;
-  asciiOut.style.color=txt.value;
+  const wInput = document.getElementById('width');
+  const widthVal=parseInt(wInput.value);
+  const font=parseInt(document.getElementById('fontsize').value);
+  const fps=parseInt(document.getElementById('fps').value);
 
-  can.width=width;
+  can.width=widthVal;
   const ratio=vid.videoHeight/vid.videoWidth;
-  can.height=Math.floor(width*ratio/2);
+  can.height=Math.floor(widthVal*ratio/2);
 
   ctx.drawImage(vid,0,0,can.width,can.height);
   const frame=ctx.getImageData(0,0,can.width,can.height);
-  asciiOut.textContent=frameToASCII(frame);
+  const txtContent = frameToASCII(frame);
+
+  const res = resolution.value;
+  if (res === 'dynamic') {
+    asciiCanvas.style.display = 'none';
+    asciiOut.style.display = 'inline-block';
+    asciiOut.style.fontSize=font+"px";
+    asciiOut.style.background=bg.value;
+    asciiOut.style.color=txt.value;
+    asciiOut.textContent=txtContent;
+  } else {
+    asciiOut.style.display = 'none';
+    asciiCanvas.style.display = 'inline-block';
+    let targetW = 1280, targetH = 720;
+    if (res === '480p') { targetW=854; targetH=480; }
+    else if (res === '1080p') { targetW=1920; targetH=1080; }
+
+    drawAsciiToCanvas(txtContent, targetW, targetH, widthVal);
+  }
+
   setTimeout(()=>requestAnimationFrame(renderLoop),1000/fps);
+}
+
+function drawAsciiToCanvas(text, w, h, charsPerLine) {
+  asciiCanvas.width = w;
+  asciiCanvas.height = h;
+  const actx = asciiCtx;
+
+  actx.fillStyle = bg.value;
+  actx.fillRect(0, 0, w, h);
+
+  const charWidth = w / charsPerLine;
+  const fontSize = charWidth / 0.6; // approx for monospace
+  const lineHeight = fontSize * 0.6; // matching css line-height 0.6em
+
+  actx.font = `${fontSize}px monospace`;
+  actx.fillStyle = txt.value;
+  actx.textBaseline = 'top';
+
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    actx.fillText(lines[i], 0, i * lineHeight);
+  }
 }
 
 function frameToASCII(frame){
@@ -140,7 +191,13 @@ function frameToASCII(frame){
 recBtn.onclick=async()=>{
   if(!running)start.click();
   if(recorder&&recorder.state==="recording")return;
-  stream=asciiOut.captureStream(parseInt(fps.value));
+
+  if (resolution.value === 'dynamic') {
+    resolution.value = '720p'; // Default to 720p for recording if dynamic
+  }
+
+  const fps = parseInt(document.getElementById('fps').value);
+  stream=asciiCanvas.captureStream(fps);
   recorder=new MediaRecorder(stream,{mimeType:"video/webm"});
   chunks=[];
   recorder.ondataavailable=e=>chunks.push(e.data);
@@ -159,7 +216,8 @@ async function saveRecording(){
   status.textContent="Saved ascii_video.webm";
 
   // Optional MP4 conversion
-  const ffmpeg=FFmpeg.createFFmpeg({log:false});
+  const { createFFmpeg, fetchFile } = FFmpeg;
+  const ffmpeg=createFFmpeg({log:false});
   await ffmpeg.load();
   await ffmpeg.FS('writeFile','input.webm',await fetchFile(blob));
   await ffmpeg.run('-i','input.webm','-c:v','libx264','output.mp4');


### PR DESCRIPTION
- Added a resolution selector dropdown to `index.html` with options for Dynamic (default), 480p, 720p, and 1080p.
- Introduced a hidden `<canvas id="ascii-canvas">` to handle fixed-resolution rendering.
- Implemented `drawAsciiToCanvas` function to render ASCII art onto the canvas with calculated font sizes.
- Updated the main `renderLoop` to switch between `<pre>` (dynamic text) and `<canvas>` (fixed resolution) based on user selection.
- Modified recording logic (`recBtn`) to capture the stream from the canvas when a fixed resolution is selected, ensuring valid video output.
- Downgraded `@ffmpeg/ffmpeg` from `0.12.4` to `0.11.0` to resolve compatibility issues with `createFFmpeg` in the existing codebase.

---
*PR created automatically by Jules for task [13411230948249789248](https://jules.google.com/task/13411230948249789248) started by @Hax0rgurl*