### PR TITLE
Fix crash on long files and implement keep audio option

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
       <option value="oldtv">Old TV</option>
     </select>
   </label>
+  <label><input type="checkbox" id="keep-audio"> Keep Audio</label>
   <button id="start">Convert</button>
   <button id="record">Record</button>
   <button id="stop">Stop</button>
@@ -84,17 +85,20 @@
   <pre id="ascii"></pre>
 </div>
 <canvas id="canvas" style="display:none;"></canvas>
+<canvas id="recording-canvas" style="display:none;"></canvas>
 <p id="status"></p>
 
 <!-- ffmpeg.wasm CDN -->
-<script src="https://unpkg.com/@ffmpeg/ffmpeg@0.12.4/dist/ffmpeg.min.js"></script>
+<script src="https://unpkg.com/@ffmpeg/ffmpeg@0.11.0/dist/ffmpeg.min.js"></script>
 
 <script>
 const chars="@#8&$%WM#*oahkbdpqwmZO0QLCJUYXzcvunxrjft/|()1{}[]?-_+~<>i!lI;:,\"^`'. ";
 const file=document.getElementById('file');
 const vid=document.getElementById('video');
 const can=document.getElementById('canvas');
+const recordingCan=document.getElementById('recording-canvas');
 const ctx=can.getContext('2d');
+const recordingCtx=recordingCan.getContext('2d');
 const asciiOut=document.getElementById('ascii');
 const start=document.getElementById('start');
 const stop=document.getElementById('stop');
@@ -112,6 +116,7 @@ const fpsInput = document.getElementById('fps');
 const fontInput = document.getElementById('fontsize');
 const bgInput = document.getElementById('bg');
 const txtInput = document.getElementById('txt');
+const keepAudio = document.getElementById('keep-audio');
 
 let running=false, recorder=null, chunks=[], stream=null;
 
@@ -143,7 +148,13 @@ function renderLoop(){
 
   ctx.drawImage(vid,0,0,can.width,can.height);
   const frame=ctx.getImageData(0,0,can.width,can.height);
-  asciiOut.textContent=frameToASCII(frame);
+  const txt = frameToASCII(frame);
+  asciiOut.textContent=txt;
+
+  if (recorder && recorder.state === "recording") {
+      drawAsciiToCanvas(txt, recordingCan, font, bgInput.value, txtInput.value);
+  }
+
   setTimeout(()=>requestAnimationFrame(renderLoop),1000/fps);
 }
 
@@ -160,6 +171,39 @@ function frameToASCII(frame){
     out+="\n";
   }
   return out;
+}
+
+function drawAsciiToCanvas(text, canvas, fontSize, bgColor, txtColor) {
+  const ctx = canvas.getContext('2d');
+  const lines = text.split('\n');
+  if (!lines.length) return;
+
+  // Set font to measure roughly
+  ctx.font = fontSize + "px monospace";
+  const charWidth = ctx.measureText("A").width;
+  const lineHeight = fontSize * 0.6;
+
+  const newWidth = Math.ceil(lines[0].length * charWidth);
+  const newHeight = Math.ceil(lines.length * lineHeight);
+
+  // Resize if needed (clears canvas)
+  if (canvas.width !== newWidth || canvas.height !== newHeight) {
+    canvas.width = newWidth;
+    canvas.height = newHeight;
+  }
+
+  // Draw background
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+  // Draw text
+  ctx.fillStyle = txtColor;
+  ctx.font = fontSize + "px monospace";
+  ctx.textBaseline = "top";
+
+  for (let i = 0; i < lines.length; i++) {
+    ctx.fillText(lines[i], 0, i * lineHeight);
+  }
 }
 
 // AI Generation Logic
@@ -216,9 +260,31 @@ aiGenerate.onclick = async () => {
 recBtn.onclick=async()=>{
   if(!running)start.click();
   if(recorder&&recorder.state==="recording")return;
-  // This might fail if browser doesn't support captureStream on Pre
+
   try {
-    stream=asciiOut.captureStream(parseInt(fpsInput.value));
+    // Initial draw
+    const font=parseInt(fontInput.value);
+    drawAsciiToCanvas(asciiOut.textContent || " ", recordingCan, font, bgInput.value, txtInput.value);
+
+    stream=recordingCan.captureStream(parseInt(fpsInput.value));
+
+    // Add audio if requested
+    if (keepAudio.checked) {
+        let audioStream = null;
+        if (vid.captureStream) {
+            audioStream = vid.captureStream();
+        } else if (vid.mozCaptureStream) {
+            audioStream = vid.mozCaptureStream();
+        }
+
+        if (audioStream) {
+            const audioTracks = audioStream.getAudioTracks();
+            if (audioTracks.length > 0) {
+                stream.addTrack(audioTracks[0]);
+            }
+        }
+    }
+
     recorder=new MediaRecorder(stream,{mimeType:"video/webm"});
     chunks=[];
     recorder.ondataavailable=e=>chunks.push(e.data);
@@ -228,8 +294,8 @@ recBtn.onclick=async()=>{
     vid.onended=()=>recorder.stop();
   } catch(e) {
       console.error(e);
-      status.textContent = "Recording not supported on this browser.";
-      alert("Recording is not supported in this environment.");
+      status.textContent = "Recording failed: " + e.message;
+      alert("Recording failed. See console for details.");
   }
 };
 
@@ -244,17 +310,22 @@ async function saveRecording(){
   // Optional MP4 conversion
   try {
       if(typeof FFmpeg === 'undefined') throw new Error("FFmpeg not loaded");
-      const ffmpeg=FFmpeg.createFFmpeg({log:false});
+      status.textContent += ". Converting to MP4...";
+      const { createFFmpeg, fetchFile } = FFmpeg;
+      const ffmpeg = createFFmpeg({ log: false });
       await ffmpeg.load();
-      await ffmpeg.FS('writeFile','input.webm',await fetchFile(blob));
-      await ffmpeg.run('-i','input.webm','-c:v','libx264','output.mp4');
-      const data=ffmpeg.FS('readFile','output.mp4');
-      const mp4URL=URL.createObjectURL(new Blob([data.buffer],{type:'video/mp4'}));
-      const b=document.createElement('a');
-      b.href=mp4URL;b.download='ascii_video.mp4';b.click();
-      status.textContent+=" and ascii_video.mp4";
+      await ffmpeg.FS('writeFile', 'input.webm', await fetchFile(blob));
+      await ffmpeg.run('-i', 'input.webm', '-c:v', 'libx264', '-preset', 'ultrafast', 'output.mp4');
+      const data = ffmpeg.FS('readFile', 'output.mp4');
+      const mp4URL = URL.createObjectURL(new Blob([data.buffer], {type: 'video/mp4'}));
+      const b = document.createElement('a');
+      b.href = mp4URL;
+      b.download = 'ascii_video.mp4';
+      b.click();
+      status.textContent += " and ascii_video.mp4";
   } catch(e) {
       console.log("FFmpeg conversion failed or skipped:", e);
+      status.textContent += ". MP4 conversion failed.";
   }
 }
 </script>


### PR DESCRIPTION
- Replaced invalid `asciiOut.captureStream()` (on `<pre>`) with a dedicated `recording-canvas` that renders the ASCII output for recording.
- Implemented "Keep Original Audio" checkbox that adds the source video's audio track to the recording stream.
- Downgraded FFmpeg to version 0.11.0 to resolve API mismatch with `createFFmpeg`.
- Added error handling and status updates to `saveRecording` to prevent crashes during MP4 conversion on large files, ensuring the WebM file is always saved first.

---
*PR created automatically by Jules for task [12761904681968535203](https://jules.google.com/task/12761904681968535203) started by @Hax0rgurl*